### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Plugin Showing Oxygen Change Tracking information in the PDF output
 Plugin which allows showing Oxygen track changes and comments, and change bars, in the classic PDF output obtained using the DITA-OT.
 The plugin is compatible and was tested with DITA-OT 3.x.
-The change bars displaying is compatble and was tested with following PDF publishing engine :
+The change bars displaying is compatible and was tested with following PDF publishing engine :
 * Antenna House 
 * FOP 2.4 and later
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Plugin Showing Oxygen Change Tracking information in the PDF output
-Plugin which allows showing Oxygen track changes and comments in the classic PDF output obtained using the DITA OT.
-The plugin is compatible and was tested with DITA OT 3.x. 
+Plugin which allows showing Oxygen track changes and comments, and change bars, in the classic PDF output obtained using the DITA-OT.
+The plugin is compatible and was tested with DITA-OT 3.x.
+The change bars displaying is compatble and was tested with following PDF publishing engine :
+* Antenna House 
+* FOP 2.4 and later
 
-This plugin does not contribute a new transformation type, it has a single parameter called "show.changes.and.comments" which should be set to "yes" in order to enable showing Oxygen track changes and comments in the generated PDF.
+This plugin does not contribute a new transformation type.
 
+## Parameters
+* __show.changes.and.comments__ set to "yes" to enable showing Oxygen track changes and comments in the generated PDF.
+* __show.changebars__ set to "yes" to enable change bars, based on Oxygen changes, in the generated PDF.
+
+## Installation
 You just need to install it and then run the regular PDF (Idiom) publishing using the PDF plugin bundled with the DITA OT.
 
 Copyright and License

--- a/com.oxygenxml.pdf.review/README.md
+++ b/com.oxygenxml.pdf.review/README.md
@@ -1,7 +1,7 @@
 # classic-pdf-review
 Plugin which allows showing Oxygen track changes and comments, and change bars, in the classic PDF output obtained using the DITA-OT.
 The plugin is compatible and was tested with DITA-OT 3.x. 
-The change bars displaying is compatble and was tested with following PDF publishing engine :
+The change bars displaying is compatible and was tested with following PDF publishing engine :
 * Antenna House 
 * FOP 2.4 and later
 

--- a/com.oxygenxml.pdf.review/README.md
+++ b/com.oxygenxml.pdf.review/README.md
@@ -1,4 +1,10 @@
 # classic-pdf-review
-Plugin which allows showing Oxygen track changes and comments in the classic PDF output obtained using the DITA-OT.
+Plugin which allows showing Oxygen track changes and comments, and change bars, in the classic PDF output obtained using the DITA-OT.
 The plugin is compatible and was tested with DITA-OT 3.x. 
-It has a single parameter called "show.oxygen.changes.and.comments" which should be set to "yes" in order to enable showing Oxygen track changes and comments in the generated PDF.
+The change bars displaying is compatble and was tested with following PDF publishing engine :
+* Antenna House 
+* FOP 2.4 and later
+
+## Parameters
+* __show.changes.and.comments__ set to "yes" to enable showing Oxygen track changes and comments in the generated PDF.
+* __show.changebars__ set to "yes" to enable change bars, based on Oxygen changes, in the generated PDF.

--- a/com.oxygenxml.pdf.review/build_reviews.xml
+++ b/com.oxygenxml.pdf.review/build_reviews.xml
@@ -36,6 +36,7 @@
             style="${dita.plugin.com.oxygenxml.pdf.review.dir}/review/review-elements-to-fo.xsl"
         	force="true">
             <param name="show.changes.and.comments" expression="${show.changes.and.comments}"/>
+            <param name="show.changebars" expression="${show.changebars}"/>
             <param name="insert.color" expression="${ct.insert.color}" if:set="ct.insert.color"/>
             <param name="delete.color" expression="${ct.delete.color}" if:set="ct.delete.color"/>
             <param name="comment.bg.color" expression="${ct.comment.bg.color}" if:set="ct.comment.bg.color"/>
@@ -58,6 +59,7 @@
                 out="${pdf2.temp.dir}/${tmpProcess3}"
                 style="${dita.plugin.com.oxygenxml.pdf.review.dir}/review/review-elements-to-fo.xsl">
                 <param name="show.changes.and.comments" expression="${show.changes.and.comments}"/>
+                <param name="show.changebars" expression="${show.changebars}"/>
                 <param name="insert.color" expression="${ct.insert.color}" if:set="ct.insert.color"/>
                 <param name="delete.color" expression="${ct.delete.color}" if:set="ct.delete.color"/>
                 <param name="comment.bg.color" expression="${ct.comment.bg.color}" if:set="ct.comment.bg.color"/>

--- a/com.oxygenxml.pdf.review/params.xml
+++ b/com.oxygenxml.pdf.review/params.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension>
     <param name="use.alpha.for.highlights" expression="'no'"/>
-    <param name="show.changes.and.comments" expression="${show.changes.and.comments}" if:set="show.changes.and.comments" xmlns:if="ant:if"/>  
+    <param name="show.changes.and.comments" expression="${show.changes.and.comments}" if:set="show.changes.and.comments" xmlns:if="ant:if"/>
+    <param name="show.changebars" expression="${show.changebars}" if:set="show.changebars" xmlns:if="ant:if"/>  
 </extension>
 

--- a/com.oxygenxml.pdf.review/plugin.xml
+++ b/com.oxygenxml.pdf.review/plugin.xml
@@ -17,6 +17,10 @@
       <val desc="No" default="true">no</val>
       <val desc="Yes">yes</val>
     </param>
+    <param name="show.changebars" desc="Show change bars based on Oxygen changes" type="enum">
+      <val desc="No" default="true">no</val>
+      <val desc="Yes">yes</val>
+    </param>
     <param name="ct.insert.color" desc="Insertion color for Oxygen tracked changes, specified as a plain color (i.e. red, yellow, blue), or with a hexadecimal equivalent (i.e. #FFFFFF).
       The default value is 'blue'." type="string"/>
     <param name="ct.delete.color" desc="Deletion color for Oxygen tracked changes, specified as a plain color (i.e. red, yellow, blue), or with a hexadecimal equivalent (i.e. #FFFFFF).

--- a/com.oxygenxml.pdf.review/review/review-elements-to-fo.xsl
+++ b/com.oxygenxml.pdf.review/review/review-elements-to-fo.xsl
@@ -8,11 +8,23 @@
     xmlns:oxy="http://www.oxygenxml.com/extensions/author">
     <xsl:include href="review-utils.xsl"/>
     <xsl:param name="show.changes.and.comments" select="'no'"/>
+    <xsl:param name="show.changebars" select="'no'"/>
     <xsl:param name="insert.color" select="'blue'"/>
     <xsl:param name="delete.color" select="'red'"/>
     <xsl:param name="comment.bg.color" select="'yellow'"/>
     
-<!-- defining the formatting of modifications  -->
+    <!-- defining the formatting of modifications  -->
+    <xsl:attribute-set name="changebar">
+        <xsl:attribute name="change-bar-class" select="generate-id()"/>
+        <xsl:attribute name="change-bar-style" select="'solid'"/>
+        <xsl:attribute name="change-bar-width" select="'1px'"/>
+    </xsl:attribute-set>
+    <xsl:attribute-set name="changebar.insert" use-attribute-sets="changebar">
+        <xsl:attribute name="change-bar-color" select="$insert.color"/>
+    </xsl:attribute-set>
+    <xsl:attribute-set name="changebar.delete" use-attribute-sets="changebar">
+        <xsl:attribute name="change-bar-color" select="$delete.color"/>
+    </xsl:attribute-set>
     <xsl:attribute-set name="insert">
         <xsl:attribute name="color" select="$insert.color"/>
     </xsl:attribute-set>
@@ -58,16 +70,28 @@
     <!-- INSERT CHANGE, USE UNDERLINE -->
     <xsl:template match="oxy:oxy-insert-hl[
         not(parent::*[local-name() = 'table' or local-name() = 'table-body' or local-name() = 'table-row' or local-name() = 'list-block' or local-name() = 'flow'])]">
+        <xsl:if test="$show.changebars = 'yes'">
+            <fo:change-bar-begin xsl:use-attribute-sets="changebar.insert"/>
+        </xsl:if>
         <fo:inline xsl:use-attribute-sets="insert">
             <xsl:apply-templates/>
         </fo:inline>
+        <xsl:if test="$show.changebars = 'yes'">
+            <fo:change-bar-end change-bar-class="{generate-id()}"/>
+        </xsl:if>
     </xsl:template>
     
     <!-- DELETE CHANGE, USE STRIKEOUT -->
     <xsl:template match="oxy:oxy-delete-hl">
+        <xsl:if test="$show.changebars = 'yes'">
+            <fo:change-bar-begin xsl:use-attribute-sets="changebar.delete"/>
+        </xsl:if>
         <fo:inline xsl:use-attribute-sets="delete">
             <xsl:apply-templates/>
-        </fo:inline>    
+        </fo:inline>
+        <xsl:if test="$show.changebars = 'yes'">
+            <fo:change-bar-end change-bar-class="{generate-id()}"/>
+        </xsl:if>
     </xsl:template>
     
     <!-- EXM-38048 Somehow wrap in list items oxy elements which are directly in it. -->


### PR DESCRIPTION
Hi,

Please find in this pull request implementation of change bars displaying in PDF.
I added a new parameter "show.changebars".
The change bars displaying is compatible and was tested with following PDF publishing engine :
* Antenna House 
* FOP 2.4 and later 

Change bars displaying is based on `fo:change-bar-begin` and `fo:change-bar-end` elements.

Thanks.